### PR TITLE
Use 2.12.8 as second target for build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val library = Project(name, file("."))
   .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
   .settings(
     scalaVersion                     := "2.11.12",
-    crossScalaVersions               := Seq("2.11.12"),
+    crossScalaVersions               := Seq("2.11.12", "2.12.8"),
     majorVersion                     := 2,
     makePublicallyAvailableOnBintray := true
   )

--- a/src/main/scala/uk/gov/hmrc/http/HttpCoreLibraryNoLongerNeeded.scala
+++ b/src/main/scala/uk/gov/hmrc/http/HttpCoreLibraryNoLongerNeeded.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Just for compatibility in `http-verbs` library